### PR TITLE
Adding option to mention a user in Discord notification

### DIFF
--- a/config.py
+++ b/config.py
@@ -46,7 +46,7 @@ SMS_TARGET = ""     # Destination phone number, including country code (eg. +155
 # In a Discord server you own/manage, navigate to Server Settings -> Integrations -> Webooks -> New Webhook. Click "Copy Webhook URL" and paste it below
 DISCORD_WEBHOOKURL = "https://discord.com/api/webhooks/xxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 DISCORD_TTS = False     # Use Discord "Text to speech" to speak the announcement
-
+DISCORD_USER_ID = ""    # (OPTIONAL) Mentions the user in the notification. With developer mode enabled, right click a user and click "Copy Id" to get Id
 
 ###############################
 ## INTERNAL VARIABLES ##

--- a/notifier.py
+++ b/notifier.py
@@ -93,6 +93,9 @@ class NotifyByPushover(Notifier):
 class NotifyByDiscord(Notifier):
     def getMessage(self):
         message = "It\'s game time"
+        #If the user id is not an empty string, append it to the end of the message
+        if cfg.DISCORD_USER_ID != "":
+            message += f" <@{cfg.DISCORD_USER_ID}>"
         return message
 
     def notify(self):
@@ -101,7 +104,7 @@ class NotifyByDiscord(Notifier):
             'content':self.getMessage(),
             'tts': cfg.DISCORD_TTS
         }
-        requests.post(cfg.DISCORD_WEBHOOKURL, postdata)            
+        requests.post(cfg.DISCORD_WEBHOOKURL, postdata)
 
 class NotifyBySMS(Notifier):
     debug = False


### PR DESCRIPTION
By default it just sends a message in a channel, which can be pretty easily missed if you're not paying attention.
Added the option to have it mention a user so that it would send a notification on mobile, and add a notification icon on desktop.