### PR TITLE
Update nwwatch.py | Added Calculations for approximate Time remaining

### DIFF
--- a/nwwatch.py
+++ b/nwwatch.py
@@ -60,7 +60,17 @@ if __name__ == "__main__":
     print("[Watching] " + cfg.LOGFILE)
     waitingInQueue = True
     queueStartTime = None
-    queuePosition = None
+    queuePosition = "0"
+    currentTime = None
+    jumpedQueue = "0"
+    elapsedTime = None
+    jumpindex = 0
+    totaljumped = 0
+    avgJumped = 0
+    remainingJumps = 0
+    totalTimeElapsed = None
+    timeleft = 0
+    startingPosition = 0
 
     # If test mode
     if(cfg.TEST_MODE):
@@ -85,10 +95,39 @@ if __name__ == "__main__":
                     # Start timing
                     if(queueStartTime is None):
                         queueStartTime = datetime.datetime.now()
+                        # Save for first jump
+                        prevTime = queueStartTime
 
+                    currentTime = datetime.datetime.now()
+                    totalTimeElapsed = currentTime - queueStartTime
+                    
                     # Extract position
+                    jumpedQueue = 0
+                    elapsedTime = 0
+                    prevQueuePosition = queuePosition
                     queuePosition = searchResult[cfg.NW_SEARCH_REGEX_INDEX]
-                    ConsoleLogger.log("Position in queue: " + queuePosition)
+                    if (startingPosition == 0):
+                        startingPosition = int(queuePosition)
+
+                    if (int(prevQueuePosition) - int(queuePosition) > 0):
+                        elapsedTime = currentTime - prevTime
+                        # calculate queue positions down + time gone by
+                        jumpedQueue = int(prevQueuePosition) - int(queuePosition)
+                        # Counter of jumps done
+                        jumpindex = jumpindex + 1
+                        # Calculate remaining jumps
+                        totaljumped = totaljumped + jumpedQueue
+                        avgJumped = totaljumped / jumpindex
+                        remainingJumps = int(queuePosition) / int(avgJumped)
+                        # calulate avg time between jumps
+                        avgJumpTime = (totalTimeElapsed.total_seconds()) / jumpindex
+                        # calculate approximate time left
+                        # convert avgJumpTime to minutes and then to int
+                        timeleft = (int(avgJumpTime) * int(remainingJumps)) // 60
+                        # Save time for next jump
+                        prevTime = currentTime
+                        # output only if jumped position
+                        ConsoleLogger.log("Position in queue: " + queuePosition + " | Time left: ~ " + str(timeleft) + " min")
 
                     if(int(queuePosition) <= cfg.NW_ALERT_AT_QUEUE_POSITION):
                         Notifier().triggerNotificationThreaded()


### PR DESCRIPTION
### **Added Calculations for approximate Time remaining + updated Output to include said time**

_Very unoptimized due to my low experience in python._

New Output
![image](https://user-images.githubusercontent.com/68249803/136089033-fc59df93-7527-44ae-8760-bc08a349fcb9.png)

Explanation:
Script now calculates Time since last jump + jumped positions.
With the calculated values we calculate the avarage time between jumps + average jumped position.
With the 2 averages and the positions left in the queue we can calculate an approximation of how much time is remaining, which gets better each jump.

_I recommend setting the NW_FILE_CHECK_FREQUENCY to 15 or lower, as to catch jumps faster and more regular._